### PR TITLE
Fixes for Whenever Setup File

### DIFF
--- a/lib/whenever/test/dsl.rb
+++ b/lib/whenever/test/dsl.rb
@@ -1,10 +1,7 @@
 module Whenever::Test
   class DSLInterpreter
-    def initialize(schedule_world, vars)
+    def initialize(schedule_world)
       @_world = schedule_world
-      vars.each do |name, value|
-        instance_variable_set("@#{name}", value)
-      end
     end
 
     def job_type(job, command)
@@ -20,6 +17,9 @@ module Whenever::Test
     end
 
     def set(name, value)
+      instance_variable_set("@#{name}".to_sym, value)
+      self.class.send(:attr_reader, name.to_sym)
+
       @_world.sets[name] = value
     end
 

--- a/lib/whenever/test/schedule.rb
+++ b/lib/whenever/test/schedule.rb
@@ -7,8 +7,9 @@ module Whenever::Test
       self.envs = {}
       self.sets = {}
 
-      dsl = DSLInterpreter.new(self, vars)
+      dsl = DSLInterpreter.new(self)
       setup_whenever(dsl)
+      vars.each { |k,v| dsl.set(k, v) }
       parse(dsl, file)
     end
 

--- a/spec/fixtures/schedule.rb
+++ b/spec/fixtures/schedule.rb
@@ -1,4 +1,4 @@
-set :output, '/var/log/whenever.log'
+set :output, "#{path}/log/whenever.log"
 set :runner_command, 'bundle exec rails runner'
 job_type :ping, 'ping :task'
 env :PATH, ENV['PATH']

--- a/spec/whenever/test/schedule_spec.rb
+++ b/spec/whenever/test/schedule_spec.rb
@@ -30,10 +30,24 @@ describe Whenever::Test::Schedule do
     end
   end
 
-  it 'makes sure `set` statements are captured ' do
+  it 'makes sure `set` statements are captured from the schedule file ' do
     schedule = Whenever::Test::Schedule.new(file: fixture)
 
     assert_equal 'bundle exec rails runner', schedule.sets[:runner_command]
+  end
+
+  it 'makes sure `set` statements are captured from the setup file ' do
+    schedule = Whenever::Test::Schedule.new(file: fixture)
+
+    assert schedule.sets[:path]
+  end
+
+  it 'makes sure user-specified variables override those in the setup file ' do
+    schedule = Whenever::Test::Schedule.new(file: fixture)
+    assert_equal 'production', schedule.sets[:environment]
+
+    schedule = Whenever::Test::Schedule.new(file: fixture, vars: { environment: 'staging' })
+    assert_equal 'staging', schedule.sets[:environment]
   end
 
   it 'makes sure `env` statements are captured ' do


### PR DESCRIPTION
This makes variables set in the whenever setup file available within the schedule file, to match the behaviour in whenever. It adds getters for the same reason.

This required that `setup_whenever` runs before user-specified variables are set, to prevent the setup file from overriding them.

Fixes #2.