### PR TITLE
Check thor tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,12 @@ describe 'Whenever Schedule' do
   it 'makes sure `runner` statements exist' do
     schedule = Whenever::Test::Schedule.new(file: 'config/schedule.rb')
 
-    assert_equal 2, schedule.jobs[:runner].count
+    expect(schedule.jobs[:runner].count).to eq(2)
 
     # Executes the actual ruby statement to make sure all constants and methods exist:
-    schedule.jobs[:runner].each { |job| instance_eval job[:task] }
+    schedule.jobs[:runner].each do |job|
+      expect { instance_eval job[:task] }.not_to raise_error
+    end
   end
 
   it 'makes sure `rake` statements exist' do
@@ -68,15 +70,15 @@ describe 'Whenever Schedule' do
     schedule = Whenever::Test::Schedule.new(vars: { environment: 'staging' })
 
     # Makes sure the rake task is defined:
-    assert Rake::Task.task_defined?(schedule.jobs[:rake].first[:task])
+    expect(Rake::Task.task_defined?(job[:task])).to be(true)
   end
 
   it 'makes sure cron alive monitor is registered in minute basis' do
     schedule = Whenever::Test::Schedule.new(file: fixture)
 
-    assert_equal 'http://myapp.com/cron-alive', schedule.jobs[:curl].first[:task]
-    assert_equal 'curl :task', schedule.jobs[:curl].first[:command]
-    assert_equal [:minute], schedule.jobs[:curl].first[:every]
+    expect(schedule.jobs[:curl].first[:task]).to eq('http://myapp.com/cron-alive')
+    expect(schedule.jobs[:curl].first[:command]).to eq('curl :task')
+    expect(schedule.jobs[:curl].first[:every]).to eq([:minute])
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ You can write a spec such as (RSpec was used in this example):
 require 'spec_helper'
 
 describe 'Whenever Schedule' do
-  before do
+  before(:context) do
     load 'Rakefile' # Makes sure rake tasks are loaded so you can assert in rake jobs
   end
 


### PR DESCRIPTION
This is intended as a stacked PR on top of the `update_rspec_syntax` branch, but I couldn't see how to do that in the GitHub PR interface when submitting to someone else's repo. If you like this change, I'm happy to recreate the PR after you merge `https://github.com/rafaelsales/whenever-test/pull/9` (assuming you like that one).

-----------------

Lately we've been using Thor for more complex processes. As a result, we have Thor tasks as well as rake tasks in our `schedule.rb`. These additions allow the tests to confirm we're referencing valid Thor tasks.